### PR TITLE
Self contained Docker build [#74]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
-FROM mcr.microsoft.com/dotnet/runtime:3.1
+FROM mcr.microsoft.com/dotnet/sdk:3.1-alpine AS build
+ENV SRC_DIR=/usr/src/MainSite
+COPY src $SRC_DIR
+RUN dotnet restore $SRC_DIR \
+    --runtime linux-x64
+RUN dotnet publish $SRC_DIR/Server \
+    --runtime linux-x64 \
+    --framework netcoreapp3.1 \
+    --self-contained \
+    --configuration Release \
+    --output /build
+
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
 WORKDIR /app
-COPY publish ./
+COPY --from=build /build .
 EXPOSE 80
 ENV ASPNETCORE_ENVIRONMENT=Staging
 ENTRYPOINT ["dotnet", "Steeltoe.Server.dll"]

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -43,7 +43,7 @@ stages:
             displayName: Load Docker Image
             inputs:
               command: load
-              arguments: $(Pipeline.Workspace)/docker-image/main-site.$(Build.BuildId).tar
+              arguments: --input $(Pipeline.Workspace)/docker-image/main-site.$(Build.BuildId).tar
           - task: Docker@2
             displayName: Push Docker Image
             inputs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -16,12 +16,13 @@ stages:
             displayName: docker build
             inputs:
               command: build
+              containerRegistry: SteeltoeContainerRegistry
               repository: main-site
           - task: Docker@2
             displayName: docker save
             inputs:
               command: save
-              arguments: main-site -o $(Build.ArtifactStagingDirectory)/main-site.tar
+              arguments: steeltoe.azurecr.io/main-site:$(Build.BuildId) -o $(Build.ArtifactStagingDirectory)/main-site.$(Build.BuildId).tar
           - publish: $(Build.ArtifactStagingDirectory)
             displayName: Publish Docker Image
             artifact: docker-image
@@ -43,12 +44,7 @@ stages:
             displayName: docker load
             inputs:
               command: load
-              arguments: --input $(Pipeline.Workspace)/docker-image/main-site.tar
-          - task: Docker@2
-            displayName: docker tag
-            inputs:
-              command: tag
-              arguments: main-site steeltoe.azurecr.io/main-site:$(Build.BuildId)
+              arguments: --input $(Pipeline.Workspace)/docker-image/main-site.$(Build.BuildId).tar
           - task: Docker@2
             displayName: docker push
             inputs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -60,14 +60,14 @@ stages:
                 $(Build.BuildId)
                 latest
           - task: CopyFiles@2
-            displayName: "Copy Kubernetes Manifest"
+            displayName: Copy Kubernetes Manifest
             inputs:
-              SourceFolder: './deploy/kubernetes'
-              Contents: '**'
-              TargetFolder: '$(Build.ArtifactStagingDirectory)/kubernetes'
+              SourceFolder: ./deploy/kubernetes
+              Contents: **
+              TargetFolder: $(Build.ArtifactStagingDirectory)/kubernetes
               CleanTargetFolder: true
           - task: PublishBuildArtifacts@1
             displayName: Stage for Release
             inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              publishLocation: 'Container'
+              PathtoPublish: $(Build.ArtifactStagingDirectory)
+              publishLocation: Container

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -46,6 +46,11 @@ stages:
               command: load
               arguments: --input $(Pipeline.Workspace)/docker-image/main-site.$(Build.BuildId).tar
           - task: Docker@2
+            displayName: docker tag
+            inputs:
+              command: tag
+              arguments: steeltoe.azurecr.io/main-site:$(Build.BuildId) steeltoe.azurecr.io/main-site:latest
+          - task: Docker@2
             displayName: docker push
             inputs:
               command: push

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -12,48 +12,56 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
-          - task: UseDotNet@2
+          - task: Docker@2
+            displayName: Build Docker Image
             inputs:
-              packageType: 'sdk'
-              version: '3.1.x'
-            displayName: "Install .NET SDK 3.1.x"
-          - script: dotnet publish './src/Server/Steeltoe.Server.csproj' --output './publish' --configuration Release --framework netcoreapp3.1 --runtime linux-x64 --self-contained
-            displayName: 'dotnet publish'
-          - publish: './publish'
-            displayName: 'Publish Server'
-            artifact: server
+              command: build
+              repository: main-site
+              tags: |
+                $(Build.BuildId)
+          - task: Docker@2
+            displayName: Save Docker Image
+            inputs:
+              command: save
+              arguments: main-site:$(Build.BuildId) -o $(Build.ArtifactStagingDirectory)/main-site.$(Build.BuildId).tar
+          - publish: $(Build.ArtifactStagingDirectory)
+            artifact: docker-image
   - stage: deploy
     displayName: Deploy
     dependsOn: assemble
     condition:
       not(eq(variables['build.reason'], 'PullRequest'))
     jobs:
-      - job: deployToStaging
-        displayName: Deploy to Staging
+      - job: deploy
+        displayName: Deploy
         pool:
           vmImage: ubuntu-latest
         steps:
           - download: current
-            artifact: server
-          - task: CopyFiles@2
-            displayName: "Stage Project"
+            artifact: docker-image
+          - task: Docker@2
+            displayName: Load Docker Image
             inputs:
-              SourceFolder: '$(Pipeline.Workspace)/server'
-              Contents: '**'
-              TargetFolder: '$(Build.ArtifactStagingDirectory)/publish'
-              CleanTargetFolder: true
-          - powershell: cp "Dockerfile" "$(Build.ArtifactStagingDirectory)/Dockerfile"
-            displayName: "Stage Dockerfile"
+              command: load
+              arguments: $(Pipeline.Workspace)/docker-image/main-site.$(Build.BuildId).tar
+          - task: Docker@2
+            displayName: Push Docker Image
+            inputs:
+              command: push
+              containerRegistry: SteeltoeContainerRegistry
+              repository: main-site
+              tags: |
+                $(Build.BuildId)
+                latest
           - task: CopyFiles@2
-            displayName: "Stage Kubernetes Manifest"
+            displayName: "Copy Kubernetes Manifest"
             inputs:
               SourceFolder: './deploy/kubernetes'
               Contents: '**'
               TargetFolder: '$(Build.ArtifactStagingDirectory)/kubernetes'
               CleanTargetFolder: true
           - task: PublishBuildArtifacts@1
-            displayName: Deploy to Staging Cluster
+            displayName: Stage for Release
             inputs:
               PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              ArtifactName: 'drop'
               publishLocation: 'Container'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -16,7 +16,6 @@ stages:
             displayName: docker build
             inputs:
               command: build
-              containerRegistry: SteeltoeContainerRegistry
               repository: main-site
           - task: Docker@2
             displayName: docker save

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -13,18 +13,18 @@ stages:
           vmImage: ubuntu-latest
         steps:
           - task: Docker@2
-            displayName: Build Docker Image
+            displayName: docker build
             inputs:
               command: build
+              containerRegistry: SteeltoeContainerRegistry
               repository: main-site
-              tags: |
-                $(Build.BuildId)
           - task: Docker@2
-            displayName: Save Docker Image
+            displayName: docker save
             inputs:
               command: save
-              arguments: main-site:$(Build.BuildId) -o $(Build.ArtifactStagingDirectory)/main-site.$(Build.BuildId).tar
+              arguments: main-site -o $(Build.ArtifactStagingDirectory)/main-site.tar
           - publish: $(Build.ArtifactStagingDirectory)
+            displayName: Publish Docker Image
             artifact: docker-image
   - stage: deploy
     displayName: Deploy
@@ -38,14 +38,20 @@ stages:
           vmImage: ubuntu-latest
         steps:
           - download: current
+            displayName: Download Docker Image
             artifact: docker-image
           - task: Docker@2
-            displayName: Load Docker Image
+            displayName: docker load
             inputs:
               command: load
-              arguments: --input $(Pipeline.Workspace)/docker-image/main-site.$(Build.BuildId).tar
+              arguments: --input $(Pipeline.Workspace)/docker-image/main-site.tar
           - task: Docker@2
-            displayName: Push Docker Image
+            displayName: docker tag
+            inputs:
+              command: tag
+              arguments: main-site steeltoe.azurecr.io/main-site:$(Build.BuildId)
+          - task: Docker@2
+            displayName: docker push
             inputs:
               command: push
               containerRegistry: SteeltoeContainerRegistry


### PR DESCRIPTION
Moves the "dotnet build" and related tasks from the pipeline and places them in the Dockerfile.  Doing so enables reproducible builds on DevOps and developer environments. 

Also added a "docker push" so that successful builds always push new Docker images to ACR, even if image is not destined for a DevOps release.