### PR TITLE
Community Calendar Invite Link

### DIFF
--- a/src/Client/Pages/Community.razor
+++ b/src/Client/Pages/Community.razor
@@ -14,7 +14,7 @@
 						Zoom meeting ID: 926 8707 7667<br />
 						Passcode: 224068<br />
 						<a href="https://VMware.zoom.us/j/92687077667?pwd=NXpPWWxlMVlEREZuNHRta2JlS2dZdz09">Zoom invite link</a><br />
-						<a href="site-data/SteeltoeCommunityMeetingInvite.ics">Add to Calendar (.ics)</a>
+						<a href="site-data/SteeltoeCommunityMeetingInvite.ics" target="_blank">Add to Calendar (.ics)</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
The calendar invite link (on the Community page) opening within the same page was causing a redirect issue. Opening in a new tab allows the download to happen without a redirect issues.