### PR TITLE
Add a slack signup link and suggest email for backup options

### DIFF
--- a/src/Client/Pages/Community.razor
+++ b/src/Client/Pages/Community.razor
@@ -28,7 +28,7 @@
 				<div class="component-whatis-title"><h2>Developers</h2></div>
 				<div class="my-5">
 					<div><Href href="https://slack.steeltoe.io" NewWindow="true">Steeltoe Slack</Href></div>
-					<div>Slack is the best place to get your questions answered, contribute to conversations, and find the latest information about the Steeltoe project.</div>
+					<div>Slack is the best place to get your questions answered, contribute to conversations, and find the latest information about the Steeltoe project. If you have trouble joining, try <a href="https://join.slack.com/t/steeltoeteam/shared_invite/zt-1cd7lh4pi-BlfQsI6nEDEX2qbh5JrRZw">this link</a> or <a href="mailto:info@steeltoe.io?subject=Slack%20Invite">email us</a>.</div>
 				</div>
 				<div class="my-5">
 					<div><Href href="https://stackoverflow.com/questions/tagged/steeltoe" NewWindow="true">Stack Overflow</Href></div>


### PR DESCRIPTION
Follow up on https://github.com/SteeltoeOSS/Documentation/issues/274 with an open-invite link (good for 100 invites) and suggestion to email if it breaks again