### PR TITLE
Allow any origin for CORS

### DIFF
--- a/src/Client/Program.cs
+++ b/src/Client/Program.cs
@@ -10,7 +10,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: "DocumentationPolicy",
            policy =>
            {
-               policy.WithOrigins("http://localhost:8082", "https://docs-dev.steeltoe.io", "https://docs.steeltoe.io")
+               policy.AllowAnyOrigin()
                        .AllowAnyHeader()
                        .WithMethods("GET");
            });

--- a/src/Client/Program.cs
+++ b/src/Client/Program.cs
@@ -10,7 +10,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: "DocumentationPolicy",
            policy =>
            {
-               policy.WithOrigins("https://docs.steeltoe.io")
+               policy.WithOrigins("http://localhost:8082", "https://docs-dev.steeltoe.io", "https://docs.steeltoe.io")
                        .AllowAnyHeader()
                        .WithMethods("GET");
            });


### PR DESCRIPTION
#133 did not fix CORS issues for loading fonts. This change should allow any host to work, so hopefully it also allows requests without the `Access-Control-Allow-Origin` header through and we can finally resolve https://github.com/SteeltoeOSS/Documentation/issues/294