### PR TITLE
Use v4 for docs links

### DIFF
--- a/src/Client/Components/Pages/CircuitBreakers/Index.razor
+++ b/src/Client/Components/Pages/CircuitBreakers/Index.razor
@@ -5,7 +5,7 @@
     This component has been discontinued from Steeltoe v4. Please click here to read more and provide feedback.
 </Banner>
 
-<Template Name="Circuit Breaker" Features="@_features" DocsUrl="/docs/circuitbreaker" MetaDescription="Prevent cascading failures in .NET applications with Steeltoe Circuit Breaker.">
+<Template Name="Circuit Breaker" Features="@_features" DocsUrl="/docs/3/circuitbreaker" MetaDescription="Prevent cascading failures in .NET applications with Steeltoe Circuit Breaker.">
     <Description>
         What do you do when a service you depend on stops responding? Circuit breakers enable you to bypass a failing service, allowing it time to recover, and preventing your users from seeing nasty error messages.
         Steeltoe includes a .NET implementation of Netflix Hystrix, a proven circuit breaker implementation with rich metrics and monitoring features.

--- a/src/Client/Components/Pages/Doc.razor
+++ b/src/Client/Components/Pages/Doc.razor
@@ -17,7 +17,7 @@ Redirecting to new docs site, please hold.
 
 @code
 {
-    private const int CurrentVersion = 3;
+    private const int CurrentVersion = 4;
 
     [Parameter] public string Area { get; set; } = "index";
     [Parameter] public string Component { get; set; } = "welcome";

--- a/src/Client/Components/Pages/Home.razor
+++ b/src/Client/Components/Pages/Home.razor
@@ -78,7 +78,7 @@
     <div class="width-90 container py-5">
         <div class="row g-0 text-center mt-3">
             <div class="col stat">
-                Steeltoe has been downloaded over <span class="number">98 million</span> times on <a href="https://www.nuget.org/profiles/SteeltoeOSS">NuGet</a>!
+                Steeltoe has been downloaded over <span class="number">110 million</span> times on <a href="https://www.nuget.org/profiles/SteeltoeOSS">NuGet</a>!
             </div>
         </div>
     </div>

--- a/src/Client/Components/Pages/Messaging/Index.razor
+++ b/src/Client/Components/Pages/Messaging/Index.razor
@@ -4,7 +4,7 @@
     This component has been discontinued from Steeltoe v4. Please click here to read more and provide feedback.
 </Banner>
 
-<Template Name="Messaging" Features="@_features" DocsUrl="/docs/messaging" MetaDescription="Use Steeltoe Messaging to build event-driven applications.">
+<Template Name="Messaging" Features="@_features" DocsUrl="/docs/3/messaging" MetaDescription="Use Steeltoe Messaging to build event-driven applications.">
 	<Description>Build highly scalable event-driven microservices connected to shared messaging systems.</Description>
     <WhatIs>
         The Steeltoe Messaging project applies core .NET concepts to the development of AMQP-based messaging solutions.

--- a/src/Client/Models/DocsSiteOptions.cs
+++ b/src/Client/Models/DocsSiteOptions.cs
@@ -6,17 +6,17 @@ public class DocsSiteOptions
 {
     [Required] public string BaseAddress { get; set; } = "https://docs.steeltoe.io";
 
-    public string ApiBrowserHome => $"{BaseAddress}/api/browser/v3/all";
+    public string ApiBrowserHome => $"{BaseAddress}/api/browser/v4/all";
 
     public string BlogHome => $"{BaseAddress}/articles/";
 
-    public string DocsHome => $"{BaseAddress}/api/v3/welcome/";
+    public string DocsHome => $"{BaseAddress}/api/v4/welcome/";
 
     public string DocsStreamHome => $"{BaseAddress}/api/v3/stream/";
 
     public string GuidesHome => $"{BaseAddress}/guides/";
 
-    public string FileShareHome => $"{BaseAddress}/api/v3/fileshares/";
+    public string FileShareHome => $"{BaseAddress}/api/v4/fileshares/";
 
-    public string DynamicLoggingHome => $"{BaseAddress}/api/v3/logging/";
+    public string DynamicLoggingHome => $"{BaseAddress}/api/v4/logging/";
 }


### PR DESCRIPTION
When redirecting to docs, use v4 as the default. Also updates a couple links (that don't exist in v4) to stick with v3